### PR TITLE
Fix controller zoom speed after 7.5 camera vfunc shift

### DIFF
--- a/EasyZoomRebornPlugin.cs
+++ b/EasyZoomRebornPlugin.cs
@@ -33,6 +33,7 @@ namespace EasyZoomReborn
         private static readonly byte[] CamDistanceOriginalBytes = new byte[8];
 
         public static float ZoomDelta = 0.75f;
+        private const int ZoomModeToggleSpeedMultiplierVTableIndex = 29;
         private delegate float GetZoomDeltaDelegate();
         private static Hook<GetZoomDeltaDelegate>? _getZoomDeltaHook;
         private static float GetZoomDeltaDetour()
@@ -147,7 +148,7 @@ namespace EasyZoomReborn
                 _getZoomDeltaHook?.Dispose(); // Dispose existing hook
 
                 var vtbl = Cam->vtbl;
-                _getZoomDeltaHook = GameInteropProvider.HookFromAddress<GetZoomDeltaDelegate>(vtbl[28], GetZoomDeltaDetour);
+                _getZoomDeltaHook = GameInteropProvider.HookFromAddress<GetZoomDeltaDelegate>(vtbl[ZoomModeToggleSpeedMultiplierVTableIndex], GetZoomDeltaDetour);
                 _getZoomDeltaHook.Enable();
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary

- Update the camera zoom multiplier hook from vtable slot 28 to slot 29 for 7.5.
- Name the hook slot as `ZoomModeToggleSpeedMultiplierVTableIndex` to document the intended target.

## Details

7.5 shifted `Client::Game::Camera` virtual function indices. Slot 28 is now `GetZoomSpeed`, while `GetZoomModeToggleSpeedMultiplier` moved to slot 29.

EZR was still hooking slot 28, replacing the normal zoom speed value with `currentZoom * 0.075f`.
This made gamepad zoom change in very small increments, while mouse wheel zoom remained unaffected because it uses a different path.
